### PR TITLE
using setTimeout to call callback function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,11 @@ module.exports = class PostCompile {
   }
 
   apply(compiler) {
+    var self = this
+
     const handler = stats => {
       if (typeof this.fn === 'function') {
-        this.fn(stats)
+        setTimeout(() => self.fn(stats))
       }
     }
 


### PR DESCRIPTION
Hi, I have encountered a small issue when displaying messages after compilation is done, by calling ```fn``` directly the resulting output would be:
```
webpack is watching the files…

 98% after emittingYour app is running at http://localhost:4000
Hash: d8d9124f6c2118c2d099
Version: webpack 4.21.0
Time: 2135ms
Built at: 2018-11-09 18:31:57
                                                Asset       Size  Chunks             Chunk Names
                                             index.js    284 KiB    main  [emitted]  main
                                         index.js.map    305 KiB    main  [emitted]  main
Entrypoint main = index.js index.js.map
[./src/index.ts] 14.8 KiB {main} [built]
...other webpack logs
    + 41 hidden modules
```
As you can see the message is displayed before the webpack logs.
If ```setTimeout``` is used the output is the following and the message is displayed properly:
```
webpack is watching the files…

Hash: d8d9124f6c2118c2d099
Version: webpack 4.21.0
Time: 1885ms
Built at: 2018-11-09 18:36:12
                                                Asset       Size  Chunks             Chunk Names
                                             index.js    284 KiB    main  [emitted]  main
                                         index.js.map    305 KiB    main  [emitted]  main
Entrypoint main = index.js index.js.map
[./src/index.ts] 14.8 KiB {main} [built]
...other webpack logs
    + 41 hidden modules
Your app is running at http://localhost:4000
```