### PR TITLE
Only first time option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,33 @@ module.exports = {
 }
 ```
 
+## Options
+You can pass options object as the second parameter
+
+| Name        | Type           | Default  |
+| ------------- |:-------------:| -----:|
+| onlyFirstTime |     boolean   |       false|
+
+### onlyFirstTime
+
+This option can be useful on `--watch` mode. <br>
+If you want the post compile hook to happend only after first compile.
+
+Code example
+
+```js
+module.exports = {
+  plugins: [
+    new PostCompile(() => {
+      console.log('Your app is running at http://localhost:4000')
+    },{
+      onlyFirstTime: true
+    })
+  ]
+}
+```
+
+
 ## Contributing
 
 1. Fork it!

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,18 @@
 module.exports = class PostCompile {
-  constructor(fn) {
+  constructor(fn, options = {onlyFirstTime: false}) {
     this.fn = fn
+    this.isFirstCompile = true
+    this.options = options
   }
 
   apply(compiler) {
     const handler = stats => {
+      if (this.options.onlyFirstTime && !this.isFirstCompile) {
+        return
+      }
       if (typeof this.fn === 'function') {
         this.fn(stats)
+        this.isFirstCompile = false
       }
     }
 


### PR DESCRIPTION
Pull request a solution for https://github.com/egoist/post-compile-webpack-plugin/issues/8 issue
Adding onlyFirstTime option to make the hook run only one on `--watch` mode